### PR TITLE
Add support for pushgateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ tinymonitoring is a set of simple Ansible roles to set up
 
 * Prometheus
 * Alertmanager
+* Pushgateway
 * Blackbox exporter
 
 behind Caddy & OAuth2 Proxy.

--- a/roles/caddy/templates/Caddyfile
+++ b/roles/caddy/templates/Caddyfile
@@ -5,5 +5,6 @@
 		output stdout
 	}
 
+	reverse_proxy /pushgateway/* 127.0.0.1:9091
 	reverse_proxy /* 127.0.0.1:4180
 }

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -17,3 +17,8 @@ alertmanager_config: "alertmanager.yml"
 # Must be absolute path
 alertmanager_rules_config: "/etc/prometheus/alert_rules.yml"
 alertmanager_web_external_url: "http://127.0.0.1:9093"
+
+install_pushgateway: false
+pushgateway_version: 1.4.3
+pushgateway_config: "pushgateway.yml"
+pushgateway_web_external_url: "http://127.0.0.1:9091"

--- a/roles/prometheus/handlers/main.yml
+++ b/roles/prometheus/handlers/main.yml
@@ -28,3 +28,9 @@
     name: alertmanager
     state: restarted
     daemon_reload: yes
+
+- name: restart pushgateway
+  systemd:
+    name: pushgateway
+    state: restarted
+    daemon_reload: yes

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -78,6 +78,9 @@
 - import_tasks: alertmanager.yml
   when: install_alertmanager | bool
 
+- import_tasks: pushgateway.yml 
+  when: install_pushgateway | bool
+
 - name: clean up old binaries
   shell: |
     rm -f /usr/local/bin/prometheus-*
@@ -85,4 +88,5 @@
     rm -f /usr/local/bin/alertmanager-*
     rm -f /usr/local/bin/amtool-*
     rm -f /usr/local/bin/blackbox_exporter-*
+    rm -f /usr/local/bin/pushgateway-*
   tags: ['never', 'clean-up-old-binaries']

--- a/roles/prometheus/tasks/pushgateway.yml
+++ b/roles/prometheus/tasks/pushgateway.yml
@@ -1,0 +1,36 @@
+---
+- name: determine installed pushgateway version
+  shell: pushgateway --version 2>&1 | awk '/pushgateway, version/{print $3}'
+  register: pushgateway_version_output
+
+- name: set pushgateway_installed_version
+  set_fact: pushgateway_installed_version="{{pushgateway_version_output.stdout}}"
+
+- name: install pushgateway
+  shell: |
+    cd `mktemp -d`
+    curl -fsSLO 'https://github.com/prometheus/pushgateway/releases/download/v{{ pushgateway_version }}/pushgateway-{{ pushgateway_version }}.linux-amd64.tar.gz'
+    tar xvfz "pushgateway-{{ pushgateway_version }}.linux-amd64.tar.gz"
+    install -m 0755 "pushgateway-{{ pushgateway_version }}.linux-amd64/pushgateway" /usr/local/bin/pushgateway
+  args:
+    warn: false
+  when: pushgateway_installed_version != pushgateway_version
+
+- name: install pushgateway config
+  copy:
+    src: "{{ pushgateway_config }}"
+    dest: /etc/prometheus/pushgateway.yml
+    owner: prometheus
+    group: prometheus
+  notify: restart pushgateway
+
+- name: install pushgateway.service
+  template:
+    src: pushgateway.service
+    dest: /etc/systemd/system/pushgateway.service
+  notify: restart pushgateway
+
+- name: enable pushgateway.service
+  systemd:
+    name: pushgateway
+    enabled: true

--- a/roles/prometheus/templates/pushgateway.service
+++ b/roles/prometheus/templates/pushgateway.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Prometheus Pushgateway
+After=network-online.target
+Wants=network-online.target systemd-networkd-wait-online.service
+
+[Service]
+Restart=on-failure
+
+User=prometheus
+Group=prometheus
+
+WorkingDirectory=/var/lib/prometheus
+
+ExecStart=/usr/local/bin/pushgateway --web.config.file /etc/prometheus/pushgateway.yml --web.listen-address "127.0.0.1:9091" --web.external-url "{{ pushgateway_web_external_url }}"
+
+PrivateTmp=true
+PrivateDevices=true
+ProtectHome=true
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds support for pushgateway, oauth2 is not setup for pushgateway as it will make accessing it from code difficult. 
pushgateway support inbuilt basic auth and it can be configured from the yaml. 

Signed-off-by: Santhosh Nagaraj S <santhosh@kinvolk.io>
